### PR TITLE
Respect the action parameter for column and color

### DIFF
--- a/Action/ConvertEmailToTask.php
+++ b/Action/ConvertEmailToTask.php
@@ -133,6 +133,8 @@ class ConvertEmailToTask extends Base
                     'title' => $subject,
                     'description' => isset($message) ? $message : '',
                     'creator_id' => is_null($connect_to_user) ? '' : $connect_to_user['id'],
+                    'column_id' => $this->getParam('column_id'),
+                    'color_id' => $this->getParam('color_id'),
                 ));
                 
                 /* Need to figure this out


### PR DESCRIPTION
The task was always created using the defaults, ignoring the given action parameter.